### PR TITLE
Enable multithread for crate download/verify

### DIFF
--- a/src/romt/common.py
+++ b/src/romt/common.py
@@ -129,7 +129,7 @@ def close_optional(f: Optional[IO[Any]]) -> None:
 def make_dirs_for(path: Path) -> None:
     parent = path.parent
     if not parent.is_dir():
-        parent.mkdir(parents=True)
+        parent.mkdir(parents=True, exist_ok=True)
 
 
 def log(log_file: Optional[IO[Any]], message: Any) -> None:


### PR DESCRIPTION
This should significantly increase the download speed for crates.

Previously, It took days to download all crates
Now, it takes hours (tested with 64 threads)
