### PR TITLE
Fix for --keep-going not working when 403 Forbidden received

### DIFF
--- a/src/romt/download.py
+++ b/src/romt/download.py
@@ -35,7 +35,7 @@ class Downloader:
                 response.raise_for_status()
                 async for chunk in response.aiter_bytes(chunk_size=16384):
                     fileobj.write(chunk)
-        except httpx.RequestError as e:
+        except httpx.HTTPError as e:
             raise error.DownloadError(url, e)
 
     def download_fileobj(self, url: str, fileobj: BinaryIO) -> None:


### PR DESCRIPTION
#8 
* In download.py Downloader class function adownload_fileobj changed
  exception from httpx.RequestError to httpx.HTTPError to catch both
  RequestError and HTTPStatusError

* References:  https://www.python-httpx.org/exceptions/