### PR TITLE
Fixing nightly manifest with duplicate packages causing downloading error

### DIFF
--- a/src/romt/toolchain.py
+++ b/src/romt/toolchain.py
@@ -391,7 +391,7 @@ class Main(dist.DistMain):
             common.iprint("  ident: {}".format(manifest.ident))
 
             targets = self.adjust_targets(manifest, base_targets)
-            packages = list(manifest.gen_available_packages(targets=targets))
+            packages = list(set(manifest.gen_available_packages(targets=targets)))
             common.iprint(
                 "  packages: {}, targets: {}".format(
                     len(packages), len(targets)
@@ -487,7 +487,7 @@ class Main(dist.DistMain):
 
                 targets = self.adjust_targets(manifest, base_targets)
                 packages = list(
-                    manifest.gen_available_packages(targets=targets)
+                    set(manifest.gen_available_packages(targets=targets))
                 )
                 common.iprint(
                     "  packages: {}, targets: {}".format(


### PR DESCRIPTION
Hi :)
I got this error while importing the todays nightly and got this error.
It was solved by removing duplicates from the packages that are generated by the manifest.
```❯ romt toolchain download pack -v -s nightly   -t aarch64-linux-android -t aarch64-unknown-linux-gnu -t arm-linux-androideabi -t arm-unknown-linux-gnueabi -t arm-unknown-linux-gnueabihf -t armv7-linux-androideabi -t armv7-unknown-linux-gnueabihf -t i686-apple-darwin -t i686-linux-android -t i686-pc-windows-gnu -t i686-pc-windows-msvc -t i686-unknown-linux-gnu -t mips-unknown-linux-gnu -t mips64-unknown-linux-gnuabi64 -t mips64el-unknown-linux-gnuabi64 -t mipsel-unknown-linux-gnu -t powerpc-unknown-linux-gnu -t powerpc64-unknown-linux-gnu -t powerpc64le-unknown-linux-gnu -t s390x-unknown-linux-gnu -t x86_64-apple-darwin -t x86_64-linux-android -t x86_64-pc-windows-gnu -t x86_64-pc-windows-msvc -t x86_64-unknown-freebsd -t x86_64-unknown-linux-gnu -t x86_64-unknown-linux-musl -t x86_64-unknown-netbsd --assume-ok
Download: nightly
[downloading] dist/channel-rust-nightly.toml
[cached file] dist/2022-03-13/channel-rust-nightly.toml
  ident: nightly-2022-03-13(1.61.0)
  packages: 258, targets: 28
Traceback (most recent call last):
  File "/home/daniel/.local/bin/romt", line 8, in <module>
    sys.exit(main())
  File "/home/daniel/.local/lib/python3.10/site-packages/romt/cli.py", line 176, in main
    romt.toolchain.Main(args).run()
  File "/home/daniel/.local/lib/python3.10/site-packages/romt/base.py", line 50, in run
    self._run()
  File "/home/daniel/.local/lib/python3.10/site-packages/romt/toolchain.py", line 640, in _run
    self.cmd_download()
  File "/home/daniel/.local/lib/python3.10/site-packages/romt/toolchain.py", line 410, in cmd_download
    self._download_verify(
  File "/home/daniel/.local/lib/python3.10/site-packages/romt/toolchain.py", line 403, in _download_verify
    self.downloader.run_job(
  File "/home/daniel/.local/lib/python3.10/site-packages/romt/download.py", line 223, in run_job
    trio.run(functools.partial(job, **kwargs), *args)
  File "/home/daniel/.local/lib/python3.10/site-packages/trio/_core/_run.py", line 1932, in run
    raise runner.main_task_outcome.error
  File "/home/daniel/.local/lib/python3.10/site-packages/romt/toolchain.py", line 372, in _download_verify_packages
    await limiter.acquire_on_behalf_of(dest_path)
  File "/home/daniel/.local/lib/python3.10/site-packages/trio/_sync.py", line 292, in acquire_on_behalf_of
    self.acquire_on_behalf_of_nowait(borrower)
  File "/home/daniel/.local/lib/python3.10/site-packages/trio/_core/_ki.py", line 159, in wrapper
    return fn(*args, **kwargs)
  File "/home/daniel/.local/lib/python3.10/site-packages/trio/_sync.py", line 255, in acquire_on_behalf_of_nowait
    raise RuntimeError(
RuntimeError: this borrower is already holding one of this CapacityLimiter's tokens
```

